### PR TITLE
Update Metrics and Flags for GPU

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,8 @@
+# This is the list of Pax's significant contributors.
+#
+# This does not necessarily list everyone who has contributed code,
+# especially since many employees of one corporation may be contributing.
+# To see the full list of contributors, see the revision history in
+# source control.
+Google LLC
+NVIDIA Corporation

--- a/paxml/main.py
+++ b/paxml/main.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2022 Google LLC.
+# Copyright 2022 The Pax Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import os
 import random
 import re
 import time
+import seqio
 import typing
 from typing import Optional, Sequence
 
@@ -159,6 +160,25 @@ flags.DEFINE_integer(
     'pythia_port', None,
     'Port for hosting Pythia service when non-Vizier built-in algorithms '
     'is used')
+flags.DEFINE_string(
+    'should_log_compiles', None,
+    'Whether to log compile time')
+flags.DEFINE_string(
+    'tfds_data_dir', None,
+    'If set, directory used to store datasets prepared by '
+    'TensorFlow Datasets that are not available in the public TFDS GCS '
+    'bucket.')
+
+## multiprocessing GPU flags
+flags.DEFINE_bool(
+    'multiprocess_gpu', False, 
+    'Whether to initialize JAX distributed for multi-host GPU')
+flags.DEFINE_string(
+    'server_addr', None, help='server ip addr')
+flags.DEFINE_integer(
+    'num_hosts', None, help='num of hosts' )
+flags.DEFINE_integer(
+    'host_idx', None, help='index of current host' )
 
 # Flags --jax_parallel_functions_output_gda, --jax_backend_target,
 # --jax_xla_backend, --jax_enable_checks are available through JAX.
@@ -359,13 +379,22 @@ def run(experiment_config: base_experiment.BaseExperiment,
 
 
 def main(argv: Sequence[str]) -> None:
+  start = time.time()
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
+
+  if FLAGS.tfds_data_dir is not None:
+    seqio.set_tfds_data_dir_override(FLAGS.tfds_data_dir)
 
   setup_jax.setup_jax(FLAGS.globally_use_hardware_rng, FLAGS.jax_backend_target,
                       FLAGS.jax_xla_backend, FLAGS.jax_enable_checks,
                       FLAGS.jax_traceback_filtering_option,
-                      FLAGS.jax_fully_async_checkpoint)
+                      FLAGS.jax_fully_async_checkpoint or FLAGS.multiprocess_gpu,
+                      FLAGS.should_log_compiles, 
+                      setup_jax.JaxDistributedOptions(FLAGS.server_addr,
+                                                      FLAGS.num_hosts,
+                                                      FLAGS.host_idx)
+                     )
 
   if FLAGS.exp is not None:
     experiment_config = get_experiment(FLAGS.exp)()
@@ -377,6 +406,9 @@ def main(argv: Sequence[str]) -> None:
   experiment_config.validate()
   run(experiment_config=experiment_config,
       enable_checkpoint_saving=FLAGS.enable_checkpoint_saving)
+
+  e2e_time = time.time() - start
+  logging.info('E2E time: {}'.format(e2e_time))
 
 
 _TASK_HANDLE_RE = re.compile(r'(?:logs\.)?(\d+)\.(.*)\.([^.]+)\.\d+')

--- a/paxml/summary_utils.py
+++ b/paxml/summary_utils.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2022 Google LLC.
+# Copyright 2022 The Pax Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR includes the following changes:
- Adds flags used for GPU training and GPU scripts (multiprocess flags, option to overwrite TFDS data dir, option to log compile times)
- Adds some additional logging (log compile times, log e2e time, add seqs_per_sec metric)
- Fixes logging for GA such that reported loss and throughput reflects that of a full batch rather than a subbatch 

Including all of the above changes in a single PR to avoid merge conflicts from multiple PRs
