### PR TITLE
Perform gradient clipping on global batch when using gradient accumulation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,8 @@
+# This is the list of Pax's significant contributors.
+#
+# This does not necessarily list everyone who has contributed code,
+# especially since many employees of one corporation may be contributing.
+# To see the full list of contributors, see the revision history in
+# source control.
+Google LLC
+NVIDIA Corporation

--- a/paxml/learners_test.py
+++ b/paxml/learners_test.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2022 Google LLC.
+# Copyright 2022 The Pax Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -64,7 +64,8 @@ class LearnersTest(test_utils.TestCase):
         grad2=jnp.array([g2], dtype=jnp.float32))
 
     with base_layer.JaxContext.new_context():
-      transformed_grads, _ = learner_instance.scale_gradients(grads)
+      grad_norm, valid_step = learner_instance.get_grad_norm_valid_step(grads)
+      transformed_grads = learner_instance.scale_gradients(grads, grad_norm)
 
     global_norm = np.linalg.norm([g1a, g1b, g2])
     local_norm1 = np.linalg.norm([g1a, g1b])


### PR DESCRIPTION
Refactoring to allow gradient clipping to be performed on full batch rather than subbatches when using `ShardedStaticAccumulator`. Note that this refactor allows us to maintain support for `enable_skip_step_on_gradient_anomalies` and requires `x+1` grad norm calculations per global batch when using `ShardedStaticAccumulator` with `x` subbatches (once per subbatch to determine whether step should be skipped, once when applying gradient clipping in base optimizer update) and requires one grad clip per global batch.

This PR should be taken together with the corresponding [Praxis PR](https://github.com/google/praxis/pull/6).