### PR TITLE
Update Logging for Gradient Accumulation

### DIFF
--- a/paxml/summary_utils.py
+++ b/paxml/summary_utils.py
@@ -376,7 +376,9 @@ def write_summary_entry(summary_writer: SummaryWriter,
                         loss: JTensor,
                         weighted_scalars_list: WeightedScalarsList,
                         summary_tensors: NestedJTensor,
-                        steps_per_sec: Optional[float] = None) -> None:
+                        steps_per_sec: Optional[float] = None,
+                        global_bs: Optional[int] = None,
+                        num_sub_batches: Optional[int] = 1) -> None:
   """Writes a summary entry into the provided SummaryWriter."""
   work_unit = platform.work_unit()
   # Scalar values must be plain Python types rather than e.g. np.int / np.float.
@@ -396,6 +398,12 @@ def write_summary_entry(summary_writer: SummaryWriter,
       status_msg += f', steps/sec {steps_per_sec}'
       write_summary_tensor(step_i, 'Steps/sec', steps_per_sec,
                            SummaryType.AGGREGATE_SCALAR)
+
+      if global_bs is not None:
+        seqs_per_sec = num_sub_batches*global_bs*steps_per_sec
+        status_msg += f', seqs/sec {seqs_per_sec}'
+        write_summary_tensor(step_i, 'Seqs/sec', seqs_per_sec,
+                             SummaryType.AGGREGATE_SCALAR)
     logging.info('Metrics values at step %d:', step_i)
     logging.info('  loss=%f', mean_loss)
     for key, value_lst in weighted_scalars_list.items():
@@ -470,7 +478,9 @@ class SummaryHandler:
                accumulate_interval_steps: Optional[int] = None,
                log_interval_steps: Optional[int] = None,
                is_async: bool = False,
-               name: str = '') -> None:
+               name: str = '',
+               global_bs: int = None,
+               num_sub_batches: int = 1) -> None:
     """Constructor.
 
     Args:
@@ -497,6 +507,8 @@ class SummaryHandler:
     self._weighted_scalars_list = collections.defaultdict(list)
     self._summary_tensors = collections.defaultdict(list)
     self._steps_per_sec = []
+    self.global_bs = global_bs
+    self.num_sub_batches = num_sub_batches
 
     if is_async:
       self._summary_pool = concurrent.futures.ThreadPoolExecutor(
@@ -668,4 +680,4 @@ class SummaryHandler:
 
     write_summary_entry(self._summary_writer, self._latest_step, losses,
                         self._weighted_scalars_list, self._summary_tensors,
-                        steps_per_sec)
+                        steps_per_sec, self.global_bs, self.num_sub_batches)

--- a/paxml/train.py
+++ b/paxml/train.py
@@ -1089,14 +1089,14 @@ def _train_and_evaluate_common(
         log_interval_steps=_train_log_interval_steps(train_p),
         is_async=bool(train_p.device_sync_interval_steps),
         name='training',
-        global_bs=train_unpadded_global_batch_size,
-        num_sub_batches=num_sub_batches)
+        global_bs=train_program.train_unpadded_global_batch_size,
+        num_sub_batches=getattr(train_p.learner.optimizer, "num_sub_batches", 1))
     eval_summary_handler = summary_utils.SummaryHandler(
         eval_summary_writer,
         train_p.summary_interval_steps,
         accumulate_interval_steps=train_p.summary_accumulate_interval_steps,
         name='eval',
-        global_bs=train_unpadded_global_batch_size)
+        global_bs=train_program.train_unpadded_global_batch_size)
 
     step_i = int(
         py_utils.maybe_unreplicate_for_fully_replicated(

--- a/paxml/train.py
+++ b/paxml/train.py
@@ -1088,12 +1088,15 @@ def _train_and_evaluate_common(
         accumulate_interval_steps=train_p.summary_accumulate_interval_steps,
         log_interval_steps=_train_log_interval_steps(train_p),
         is_async=bool(train_p.device_sync_interval_steps),
-        name='training')
+        name='training',
+        global_bs=train_unpadded_global_batch_size,
+        num_sub_batches=num_sub_batches)
     eval_summary_handler = summary_utils.SummaryHandler(
         eval_summary_writer,
         train_p.summary_interval_steps,
         accumulate_interval_steps=train_p.summary_accumulate_interval_steps,
-        name='eval')
+        name='eval',
+        global_bs=train_unpadded_global_batch_size)
 
     step_i = int(
         py_utils.maybe_unreplicate_for_fully_replicated(


### PR DESCRIPTION
This PR includes the changes to `train.py` originally from PR https://github.com/google/paxml/pull/8. In particular:

- Fixes logging for gradient accumulation such that reported loss and throughput reflects that of a full batch rather than a subbatch
- Adds `seqs/sec` metric