### PR TITLE
Make num_train_steps configurable in gpu configs

### DIFF
--- a/paxml/contrib/gpu/scripts_gpu/configs.py
+++ b/paxml/contrib/gpu/scripts_gpu/configs.py
@@ -138,6 +138,7 @@ class GPT126M(TransformerLmSpmdAdam):
   def task(self) -> tasks_lib.SingleTask.HParams:
     task_p = super().task()
     task_p = configure_gpt3_task(self, task_p)
+    task_p.train.num_train_steps = self.MAX_STEPS
     
     model_p = task_p.model
     


### PR DESCRIPTION
Minor change to `paxml/contrib/gpu/scripts_gpu/configs.py` which allows `num_train_steps` to be configured. 