### PR TITLE
Pin JAX version in Dockerfile

### DIFF
--- a/paxml/contrib/gpu/Dockerfile
+++ b/paxml/contrib/gpu/Dockerfile
@@ -3,8 +3,6 @@ FROM ${FROM_IMAGE_NAME}
 
 RUN apt update && apt install -y python3-pip &&  apt install -y git
 
-RUN pip install --upgrade "jax[cuda12_pip]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-
 WORKDIR /pax
 ENV PYTHONPATH=/pax:/pax/paxml:/pax/praxis
 
@@ -18,6 +16,9 @@ RUN git clone https://github.com/google/paxml \
 
 COPY paxml/contrib/gpu/ paxml/paxml/contrib/gpu/
 RUN pip install -r paxml/paxml/contrib/gpu/scripts_gpu/requirements.txt
+RUN pip install -r paxml/paxml/contrib/gpu/scripts_gpu/cuda_requirements.txt
+
+RUN python3 -m pip install jax==0.4.8 jaxlib==0.4.7+cuda12.cudnn88 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 ENV XLA_FLAGS="--xla_gpu_enable_triton_gemm=false --xla_gpu_enable_latency_hiding_scheduler=true ${XLA_FLAGS}"
 

--- a/paxml/contrib/gpu/scripts_gpu/cuda_requirements.txt
+++ b/paxml/contrib/gpu/scripts_gpu/cuda_requirements.txt
@@ -1,0 +1,8 @@
+nvidia-cublas-cu12==12.1.0.26
+nvidia-cuda-nvcc-cu12==12.1.66
+nvidia-cuda-runtime-cu12==12.1.55
+nvidia-cudnn-cu12==8.9.0.131
+nvidia-cufft-cu12==11.0.2.4
+nvidia-cusolver-cu12==11.4.4.55
+nvidia-cusparse-cu12==12.0.2.55
+nvidia-nvjitlink-cu12==12.1.55


### PR DESCRIPTION
This PR pins the JAX version in our Dockerfile to avoid potential conflicts that arise from frozen `requirements.txt` dependencies + latest JAX. 