### PR TITLE
[NVIDIA] Fix Default Container in Example Submit File

### DIFF
--- a/paxml/contrib/gpu/scripts_gpu/example_slurm_pile.sub
+++ b/paxml/contrib/gpu/scripts_gpu/example_slurm_pile.sub
@@ -29,7 +29,7 @@ set -eux
 # File system and volume glue code
 #-------------------------------------------------------------------------------
 # << CHANGE ! >>
-CONTAINER="${CONTAINER:-ghcr.io/nvidia/pax:pax-release-07-10-2023}"
+CONTAINER="${CONTAINER:-ghcr.io/nvidia/pax:pax-release-2023-06-23}"
 
 # << CHANGE ! >>
 BASE_WORKSPACE_DIR=${BASE_WORKSPACE_DIR} ## location to write logs and checkpoints to


### PR DESCRIPTION
Corrects the default container in `example_slurm_pile.sub`. 