### PR TITLE
Use CPU-only version of TensorFlow

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ protobuf==3.19.6
 pyglove
 seqio-nightly
 t5
-tensorflow~=2.9.2
+tensorflow-cpu~=2.9.2
 tensorflow-text~=2.9.0
 tensorstore
 tensorflow-datasets==4.8.3


### PR DESCRIPTION
Currently we see the following (harmless) warnings when using Pax, even though Pax seemingly does not require GPU support in TF. This PR switches to using the CPU-only flavor of TF.
```
2023-08-22 18:57:28.132079: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/nvidia/lib:/usr/local/nvidia/lib64
2023-08-22 18:57:32.630600: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/nvidia/lib:/usr/local/nvidia/lib64
2023-08-22 18:57:32.630684: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcublas.so.11'; dlerror: libcublas.so.11: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/nvidia/lib:/usr/local/nvidia/lib64
2023-08-22 18:57:32.630749: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcublasLt.so.11'; dlerror: libcublasLt.so.11: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/nvidia/lib:/usr/local/nvidia/lib64
2023-08-22 18:57:32.630813: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcufft.so.10'; dlerror: libcufft.so.10: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/nvidia/lib:/usr/local/nvidia/lib64
2023-08-22 18:57:32.653431: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcusparse.so.11'; dlerror: libcusparse.so.11: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/nvidia/lib:/usr/local/nvidia/lib64
2023-08-22 18:57:32.653582: W tensorflow/core/common_runtime/gpu/gpu_device.cc:1850] Cannot dlopen some GPU libraries. Please make sure the missing libraries mentioned above are installed properly if you would like to use GPU. Follow the guide at https://www.tensorflow.org//install/gpu for how to download and setup the required libraries for your platform.
Skipping registering GPU devices...
```

The PR is speculative, because I have not verified that using the CPU-only version removes the warnings. I'll test that and report back.

Apologies for the whitespace change mixed-in, there was a newline missing at the EOF.