### PR TITLE
[NVIDIA] Add synthetic configs for benchmarking

### DIFF
--- a/paxml/contrib/gpu/scripts_gpu/benchmark_gpt_multinode.sh
+++ b/paxml/contrib/gpu/scripts_gpu/benchmark_gpt_multinode.sh
@@ -17,10 +17,11 @@
 # Assumes you are using a SLURM cluster. Edit flags under --multiprocess_gpu below to suit your setup
 set -u
 
-PREC=${1:-"bfloat16"}        # Precision (float32, bfloat16)
-NUM_GPUS=${2:-8}      # Number of GPUs (1, 2, 4, 8)
-PERCORE_BATCH_SIZE=${3:-4}
-LOG_DIR=${4:-"test_logdir"}
+CONFIG=${1:-"Synthetic126M"}
+PREC=${2:-"bfloat16"}        # Precision (float32, bfloat16)
+NUM_GPUS=${3:-8}      # Number of GPUs (1, 2, 4, 8)
+PERCORE_BATCH_SIZE=${4:-4}
+LOG_DIR=${5:-"test_logdir"}
 
 export VOCAB_PATH=None
 export XLA_PYTHON_CLIENT_MEM_FRACTION=${XLA_PYTHON_CLIENT_MEM_FRACTION:-0.85}
@@ -32,11 +33,10 @@ BASE_XLA_FLAGS=${BASE_XLA_FLAGS:-"--xla_gpu_enable_latency_hiding_scheduler=true
 export XLA_FLAGS="$BASE_XLA_FLAGS ${XLA_FLAGS:-}"
 
 
-## NOTE: 126M trained with pure data parallel
 mkdir -p $LOG_DIR
 python3 -u -m paxml.main \
     --job_log_dir=$LOG_DIR \
-    --fdl_config=paxml.contrib.gpu.scripts_gpu.configs.Synthetic126M \
+    --fdl_config=paxml.contrib.gpu.scripts_gpu.configs.${CONFIG} \
     --fdl.FPROP_DTYPE=\"${PREC}\" \
     --fdl.PERCORE_BATCH_SIZE=$PERCORE_BATCH_SIZE \
     --multiprocess_gpu \

--- a/paxml/contrib/gpu/scripts_gpu/benchmark_gpt_multinode.sh
+++ b/paxml/contrib/gpu/scripts_gpu/benchmark_gpt_multinode.sh
@@ -1,0 +1,47 @@
+# coding=utf-8
+# Copyright 2022 The Pax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#! /bin/bash
+# Assumes you are using a SLURM cluster. Edit flags under --multiprocess_gpu below to suit your setup
+set -u
+
+PREC=${1:-"bfloat16"}        # Precision (float32, bfloat16)
+NUM_GPUS=${2:-8}      # Number of GPUs (1, 2, 4, 8)
+PERCORE_BATCH_SIZE=${3:-4}
+LOG_DIR=${4:-"test_logdir"}
+
+export VOCAB_PATH=None
+export XLA_PYTHON_CLIENT_MEM_FRACTION=${XLA_PYTHON_CLIENT_MEM_FRACTION:-0.85}
+BASE_XLA_FLAGS=${BASE_XLA_FLAGS:-"--xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_enable_triton_gemm=false
+                       --xla_gpu_simplify_all_fp_conversions --xla_gpu_enable_async_all_gather=true
+                       --xla_gpu_enable_async_reduce_scatter=true  --xla_gpu_enable_highest_priority_async_stream=true
+                       --xla_gpu_enable_triton_softmax_fusion=false  --xla_gpu_all_reduce_combine_threshold_bytes=51200
+                       --xla_gpu_graph_level=0 --xla_gpu_enable_async_all_reduce=true"}
+export XLA_FLAGS="$BASE_XLA_FLAGS ${XLA_FLAGS:-}"
+
+
+## NOTE: 126M trained with pure data parallel
+mkdir -p $LOG_DIR
+python3 -u -m paxml.main \
+    --job_log_dir=$LOG_DIR \
+    --fdl_config=paxml.contrib.gpu.scripts_gpu.configs.Synthetic126M \
+    --fdl.FPROP_DTYPE=\"${PREC}\" \
+    --fdl.PERCORE_BATCH_SIZE=$PERCORE_BATCH_SIZE \
+    --multiprocess_gpu \
+    --server_addr=${SLURM_LAUNCH_NODE_IPADDR}:12345 \
+    --num_hosts=$SLURM_NTASKS \
+    --host_idx=$SLURM_PROCID \
+    --alsologtostderr
+

--- a/paxml/contrib/gpu/scripts_gpu/benchmark_gpt_multinode.sh
+++ b/paxml/contrib/gpu/scripts_gpu/benchmark_gpt_multinode.sh
@@ -43,5 +43,7 @@ python3 -u -m paxml.main \
     --server_addr=${SLURM_LAUNCH_NODE_IPADDR}:12345 \
     --num_hosts=$SLURM_NTASKS \
     --host_idx=$SLURM_PROCID \
+    --enable_checkpoint_saving=False \
+    --fdl.MAX_STEPS=100 \
     --alsologtostderr
 

--- a/paxml/contrib/gpu/scripts_gpu/configs.py
+++ b/paxml/contrib/gpu/scripts_gpu/configs.py
@@ -117,8 +117,6 @@ class GPT126M(TransformerLmSpmdAdam):
   DIMS_PER_HEAD = 64
 
   TRAINABLE_POSITION_EMB = True
-  TRAINABLE_PE_MAX_SEQ_LEN = MAX_SEQ_LEN
-
   USE_BIAS = True
   LAYERNORM_EPSILON = 1e-5
   ATTEN_LOGIT_CAP = -1.0
@@ -145,6 +143,8 @@ class GPT126M(TransformerLmSpmdAdam):
   LR_COS_MAX = 1.0
 
   def task(self) -> pax_fiddle.Config[tasks_lib.SingleTask]:
+    self.TRAINABLE_PE_MAX_SEQ_LEN = self.MAX_SEQ_LEN
+
     task_p = super().task()
     task_p = configure_gpt3_task(self, task_p)
     task_p.train.num_train_steps = self.MAX_STEPS

--- a/paxml/contrib/gpu/scripts_gpu/configs.py
+++ b/paxml/contrib/gpu/scripts_gpu/configs.py
@@ -96,7 +96,6 @@ def configure_gpt3_task(
   return task_p
 
 ## 8 node
-@experiment_registry.register
 class GPT126MBase(TransformerLmSpmdAdam):
 
   USE_REPEATED_LAYER = False
@@ -173,7 +172,6 @@ class GPT126MBase(TransformerLmSpmdAdam):
     return task_p
 
 ## 32 node
-@experiment_registry.register
 class GPT5BBase(GPT126MBase):
 
   USE_REPEATED_LAYER = True
@@ -219,7 +217,6 @@ class GPT5BBase(GPT126MBase):
 
 
 ## 96 node
-@experiment_registry.register
 class GPT175BBase(GPT126MBase):
 
   NUM_LAYERS = 96
@@ -281,11 +278,13 @@ class Synthetic126M(GPT126MBase, SyntheticDataset):
     task_p = super().task()
     return task_p
 
+@experiment_registry.register
 class Synthetic5B(GPT5BBase, SyntheticDataset):
   def task(self) -> pax_fiddle.Config[tasks_lib.SingleTask]:
     task_p = super().task()
     return task_p
 
+@experiment_registry.register
 class Synthetic175B(GPT175BBase, SyntheticDataset):
   def task(self) -> pax_fiddle.Config[tasks_lib.SingleTask]:
     task_p = super().task()

--- a/paxml/contrib/gpu/scripts_gpu/configs.py
+++ b/paxml/contrib/gpu/scripts_gpu/configs.py
@@ -95,10 +95,9 @@ def configure_gpt3_task(
 
   return task_p
 
-
 ## 8 node
 @experiment_registry.register
-class GPT126M(TransformerLmSpmdAdam):
+class GPT126MBase(TransformerLmSpmdAdam):
 
   USE_REPEATED_LAYER = False
   ICI_MESH_SHAPE = [8, 1, 1]
@@ -173,35 +172,9 @@ class GPT126M(TransformerLmSpmdAdam):
 
     return task_p
 
-@experiment_registry.register
-class Synthetic126M(GPT126M, SyntheticDataset):
-  def task(self) -> pax_fiddle.Config[tasks_lib.SingleTask]:
-    task_p = super().task()
-    return task_p
-
-@experiment_registry.register
-class Pile126M(GPT126M, PileUnsupervisedDataset):
-
-  def task(self) -> pax_fiddle.Config[tasks_lib.SingleTask]:
-    task_p = super().task()
-    return task_p
-
-
-@experiment_registry.register
-class Lambada126M(GPT126M, LambadaDataset):
-
-  ICI_MESH_SHAPE = [8,1,1]
-
-  def task(self) -> pax_fiddle.Config[tasks_lib.SingleTask]:
-    task_p = super().task()
-    task_p.train.always_use_train_for_model_init=False
-    task_p.model.report_strict_acc=True
-    return task_p
-
-
 ## 32 node
 @experiment_registry.register
-class GPT5B(Pile126M):
+class GPT5BBase(GPT126MBase):
 
   USE_REPEATED_LAYER = True
   ICI_MESH_SHAPE = [1, 8, 1]
@@ -247,7 +220,7 @@ class GPT5B(Pile126M):
 
 ## 96 node
 @experiment_registry.register
-class GPT175B(Pile126M):
+class GPT175BBase(GPT126MBase):
 
   NUM_LAYERS = 96
   NUM_HEADS = 96
@@ -300,3 +273,57 @@ class GPT175B(Pile126M):
   def task(self) -> pax_fiddle.Config[tasks_lib.SingleTask]:
     task_p = super().task()
     return task_p
+
+### synthetic configs
+@experiment_registry.register
+class Synthetic126M(GPT126MBase, SyntheticDataset):
+  def task(self) -> pax_fiddle.Config[tasks_lib.SingleTask]:
+    task_p = super().task()
+    return task_p
+
+class Synthetic5B(GPT5BBase, SyntheticDataset):
+  def task(self) -> pax_fiddle.Config[tasks_lib.SingleTask]:
+    task_p = super().task()
+    return task_p
+
+class Synthetic175B(GPT175BBase, SyntheticDataset):
+  def task(self) -> pax_fiddle.Config[tasks_lib.SingleTask]:
+    task_p = super().task()
+    return task_p
+
+### configs with the Pile dataset
+@experiment_registry.register
+class Pile126M(GPT126MBase, PileUnsupervisedDataset):
+  def task(self) -> pax_fiddle.Config[tasks_lib.SingleTask]:
+    task_p = super().task()
+    return task_p
+
+@experiment_registry.register
+class Pile5B(GPT5BBase, PileUnsupervisedDataset):
+  def task(self) -> pax_fiddle.Config[tasks_lib.SingleTask]:
+    task_p = super().task()
+    return task_p
+
+@experiment_registry.register
+class Pile175B(GPT175BBase, PileUnsupervisedDataset):
+  def task(self) -> pax_fiddle.Config[tasks_lib.SingleTask]:
+    task_p = super().task()
+    return task_p
+
+
+### example of a config that runs evaluation on the lambada dataset
+@experiment_registry.register
+class Lambada126M(GPT126MBase, LambadaDataset):
+
+  ICI_MESH_SHAPE = [8,1,1]
+
+  def task(self) -> pax_fiddle.Config[tasks_lib.SingleTask]:
+    task_p = super().task()
+    task_p.train.always_use_train_for_model_init=False
+    task_p.model.report_strict_acc=True
+    return task_p
+
+
+### legacy aliases
+GPT5B = Pile5B
+GPT175B = Pile175B

--- a/paxml/contrib/gpu/scripts_gpu/configs.py
+++ b/paxml/contrib/gpu/scripts_gpu/configs.py
@@ -22,6 +22,7 @@ from paxml import tasks_lib
 from paxml.contrib.gpu.scripts_gpu.tasks import LambadaDataset
 from paxml.contrib.gpu.scripts_gpu.tasks import PileUnsupervisedDataset
 from paxml.tasks.lm.params.c4 import TransformerLmSpmdAdam
+from paxml.tasks.lm.params.lm_cloud import SyntheticDataset
 from praxis import base_layer
 from praxis import layers
 from praxis import optimizers
@@ -172,6 +173,11 @@ class GPT126M(TransformerLmSpmdAdam):
 
     return task_p
 
+@experiment_registry.register
+class Synthetic126M(GPT126M, SyntheticDataset):
+  def task(self) -> pax_fiddle.Config[tasks_lib.SingleTask]:
+    task_p = super().task()
+    return task_p
 
 @experiment_registry.register
 class Pile126M(GPT126M, PileUnsupervisedDataset):

--- a/paxml/contrib/gpu/scripts_gpu/tfds_lambada.py
+++ b/paxml/contrib/gpu/scripts_gpu/tfds_lambada.py
@@ -77,8 +77,6 @@ except ImportError:
     parser = json.Parser()
 
 
-_CITATION = """
-"""
 _DATASET_MODES = ["lm"]
 
 _URLS = {


### PR DESCRIPTION
This PR adds synthetic dataset versions of the configs in `configs.py`  for benchmarking, adds an accompanying bash script, and makes a few other minor fixes to some `contrib/gpu` scripts. 