### PR TITLE
Set eval_loop_num_batches=-1 for lambada eval

### DIFF
--- a/paxml/contrib/gpu/scripts_gpu/tasks.py
+++ b/paxml/contrib/gpu/scripts_gpu/tasks.py
@@ -174,6 +174,7 @@ class LambadaDataset(base_experiment.BaseExperiment):
         num_infeed_hosts=num_infeed_hosts,
         reset_for_eval=False if is_training else True,
         shuffle=False,
+        eval_loop_num_batches=-1,
     )
     return p
 


### PR DESCRIPTION
A recent change in Paxml resulted in Lambada evaluation running over a single batch by default rather than exhausting the dataset. This PR sets `eval_loop_num_batches=-1` when running Lambada evaluation to fix the issue. 