### PR TITLE
[NVIDIA] Add config option to use cudnn flash attention

### DIFF
--- a/paxml/tasks/lm/model_params.py
+++ b/paxml/tasks/lm/model_params.py
@@ -33,6 +33,7 @@ from praxis import py_utils
 from praxis import schedules
 from praxis.layers import activations
 from praxis.layers import embedding_softmax
+from praxis.layers import gpu_fast_attention
 from praxis.layers import models
 from praxis.layers import transformer_models
 from praxis.layers.injection import fp8_nvidia_gpu as fp8_ops
@@ -583,6 +584,7 @@ class TransformerLmSpmdAdafactor(base_experiment.BaseExperiment):
   DECAY_END = 100000
   USE_FP8 = False
   USE_EXPERT_PARALLEL = False  # GPU specific.
+  USE_CUDNN_FLASH_ATTENTION = False
 
   # optimizer related
   DROPOUT_PROB = 0.0
@@ -698,6 +700,17 @@ class TransformerLmSpmdAdafactor(base_experiment.BaseExperiment):
       )
     if self.USE_ROTARY_POSITION_EMB:
       transformer_layer_p.tr_atten_tpl.use_rotary_position_emb = True
+
+    if self.USE_CUDNN_FLASH_ATTENTION:
+      assert transformer_layer_p.tr_atten_tpl.cls == layers.DotProductAttention
+      causal_mode = transformer_models.LanguageModelType.CAUSAL
+      assert model_p.lm_tpl.model_type == causal_mode
+      fused_tr_atten_tpl = pax_fiddle.Config(
+          gpu_fast_attention.GpuCudnnFusedDotProductAttention,
+          is_causal=True,
+      )
+      fused_tr_atten_tpl.copy_fields_from(transformer_layer_p.tr_atten_tpl)
+      transformer_layer_p.tr_atten_tpl = fused_tr_atten_tpl
 
     if self.USE_REPEATED_LAYER:
       model_p.lm_tpl.stacked_transformer_tpl = pax_fiddle.Config(


### PR DESCRIPTION
This PR is to allow users to enable the cudnn flash attention. The PR depends on https://github.com/google/praxis/pull/53.

The preliminary results for the GPT3-5B, we can observe ~30% perf improve on 8xH100 GPUs.

With this PR, users can simply set `USE_CUDNN_FLASH_ATTENTION=True` in their config and then the attention part will be replaced with the cudnn flash attention.

cc. @nluehr @zhangqiaorjc 